### PR TITLE
Feat/replicate signup

### DIFF
--- a/src/replication/replication_manager.py
+++ b/src/replication/replication_manager.py
@@ -1,0 +1,117 @@
+import concurrent.futures
+import grpc
+import logging
+from typing import Dict, List
+
+import src.protocol.grpc.replication_pb2 as replication
+import src.protocol.grpc.replication_pb2_grpc as replication_grpc
+
+logger = logging.getLogger(__name__)
+
+
+class ReplicationManager:
+    """
+    Manages replication of operations to followers.
+    """
+
+    def __init__(self, state):
+        self.state = state
+
+    def replicate_to_followers(
+        self, service_name, method_name, serialized_request, operation_id
+    ):
+        """Replicate an operation to all followers."""
+        if self.state.role != "leader":
+            logger.warning("Only the leader can replicate operations")
+            return
+
+        successes = 1  # Count self as success
+        futures = []
+
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            for peer_id, peer_address in self.state.peers.items():
+                futures.append(
+                    executor.submit(
+                        self.replicate_to_one_follower,
+                        peer_id,
+                        peer_address,
+                        service_name,
+                        method_name,
+                        serialized_request,
+                        operation_id,
+                    )
+                )
+
+            for future in concurrent.futures.as_completed(futures):
+                try:
+                    if future.result():
+                        successes += 1
+                except Exception as e:
+                    logger.error(f"Error in replication: {str(e)}")
+
+        # Check if we have majority
+        if successes > (len(self.state.peers) + 1) / 2:
+            logger.info(
+                f"Operation {operation_id} successfully replicated to majority of followers"
+            )
+        else:
+            logger.warning(
+                f"Failed to replicate operation {operation_id} to majority of followers"
+            )
+
+    def replicate_to_one_follower(
+        self,
+        peer_id,
+        peer_address,
+        service_name,
+        method_name,
+        serialized_request,
+        operation_id,
+    ):
+        """Replicate an operation to a single follower."""
+        try:
+            with grpc.insecure_channel(peer_address) as channel:
+                stub = replication_grpc.ReplicationServiceStub(channel)
+
+                request = replication.OperationRequest(
+                    service_name=service_name,
+                    method_name=method_name,
+                    serialized_request=serialized_request,
+                    operation_id=operation_id,
+                    server_id=self.state.server_id,
+                    term=self.state.term,
+                )
+
+                response = stub.ReplicateOperation(request, timeout=2)
+
+                if response.success:
+                    logger.info(
+                        f"Successfully replicated {service_name}.{method_name} to {peer_id}"
+                    )
+                    return True
+                else:
+                    logger.warning(
+                        f"Failed to replicate {service_name}.{method_name} to {peer_id}"
+                    )
+                    return False
+        except Exception as e:
+            logger.error(f"Error replicating to {peer_id}: {str(e)}")
+            return False
+
+    def log_operation(self, service, method, parameters, result, operation_id):
+        """Log an operation to the operation log."""
+        self.state.operation_log.append(
+            {
+                "service": service,
+                "method": method,
+                "parameters": parameters,
+                "result": result,
+                "id": operation_id,
+                "term": self.state.term,
+            }
+        )
+
+    def get_next_operation_id(self):
+        """Get the next operation ID."""
+        self.state.last_operation_id += 1
+        return self.state.last_operation_id

--- a/src/server/grpc_server.py
+++ b/src/server/grpc_server.py
@@ -38,7 +38,9 @@ class GRPCServer:
         # Initialize this replica Node
         self.replica = ReplicaNode(self.server_id, self.address, self.peers)
         self.chat_servicer = ChatServicer(self.replica)
-        self.replication_servicer = ReplicationServicer(self.replica)
+        self.replication_servicer = ReplicationServicer(
+            self.replica, self.chat_servicer
+        )
 
         # Create gRPC server
         self.server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))


### PR DESCRIPTION
fix #127 

This adds server's ability to replicate client's requests (in particula, `SignUp`, across replicas). We can follow the same pattern for other write requests (ones that mutate data). 

To test: signup when one server is a leader, log in and log out.  Then crash the leader and keep log in with the same user. Log in should be successful, showing that the user registration was replicated. 


## How To Test

After installing all the requirements (e.x. `make install && make install-dev`) and loading the new environment (as detailed in root README.md), you can start the first replica by running: 

```bash
make run-server MODE=grpc SERVER_ID=server1 PORT=5555
```
This will start first server in the network/cluster. To add more server replicas (say 2), run: 

```bash
make run-server MODE=grpc SERVER_ID=server2 PORT=5556 PEERS=x.x.x.x:5555
```
where `x.x.x.x` is the address of the first server (e.x. "localhost" if on the same machine, the actual address if on separate machine). 
and
 
```bash
make run-server MODE=grpc SERVER_ID=server3 PORT=5557 PEERS=x.x.x.x:5555,y.y.y.y:5556
```
where `y.y.y.y` is address of second replica. 

An example of last command can be something like: 

```bash
make run-server MODE=grpc SERVER_ID=server3 PORT=5557 PEERS=10.250.10.214:5555,10.250.10.214:5556
```